### PR TITLE
Use relative URLs and double brackets when possible to support translations

### DIFF
--- a/content/index.es.md
+++ b/content/index.es.md
@@ -85,6 +85,6 @@ Los tutoriales proporcionan orientación para crear componentes que cumplen con 
 [Prácticas para el autor de WAI-ARIA](https://www.w3.org/TR/wai-aria-practices/)
 : Proporciona aproximaciones, consejos y ejemplos para ayudar a los desarrolladores de aplicaciones web a hacer widgets, navegación y comportamientos accesibles a través de los roles, estados y propiedades de WAI-ARIA (Accessible Rich Internet Applications).
 
-[Desarrollando sitios web para personas mayores: cómo se aplica WCAG](https://www.w3.org/WAI/older-users/developing/)
+[Desarrollando sitios web para personas mayores: cómo se aplica WCAG](/older-users/developing/)
 : Enumera casos de éxito y técnicas WCAG específicos que mejoran la accesibilidad y la usabilidad para las personas mayores particularmente.
 {:.paragraph-like}

--- a/content/index.es.md
+++ b/content/index.es.md
@@ -49,19 +49,19 @@ Orientación para escribir, diseñar y desarrollar sobre la accesibilidad.
 
 Estos trucos presentan algunas consideraciones básicas a fin de hacer su sitio web más accesible para las personas con discapacidad. Incluyen enlaces a orientación adicional.
 
-[Escribir para la accesibilidad web](/tips/writing/) 
+[[Escribir para la accesibilidad web]](/tips/writing/) 
 : Trucos para escribir y presentar contenido.
 
-[Diseñar para la accesibilidad web](/tips/designing/) 
+[[Diseñar para la accesibilidad web]](/tips/designing/) 
 : Trucos para el diseño visual y de interfaces de usuario.
 
-[Desarrollar para la accesibilidad web](/tips/developing/) 
+[[Desarrollar para la accesibilidad web]](/tips/developing/) 
 : Trucos de programación.
 {:.paragraph-like}
 
 ## Recursos para audio y vídeo
 
-[Cómo hacer los medios de audio y vídeo accesibles](https://www.w3.org/WAI/media/av/)
+[[Cómo hacer los medios de audio y vídeo accesibles]](/media/av/)
 
 : Le ayuda a aprender y a crear subtítulos, audiodescripción para la información visual, transcripciones descriptivas y lengua de signos para los medios. Incluye orientación para crear vídeos nuevos y sobre la accesibilidad de los reproductores multimedia. Presenta experiencias de usuario y beneficios para las organizaciones.
 {:.paragraph-like}
@@ -70,12 +70,12 @@ Estos trucos presentan algunas consideraciones básicas a fin de hacer su sitio 
 
 Los tutoriales proporcionan orientación para crear componentes que cumplen con las Pautas de Accesibilidad para el Contenido Web (WCAG), los cuales son más accesibles para las personas con discapacidad y ofrecen una experiencia de usuario mejorada para todo el mundo.
 
-* **[Tutorial de estructura de la página](https://www.w3.org/WAI/tutorials/page-structure/)**
-* **[Tutorial de menús](https://www.w3.org/WAI/tutorials/menus/)**
-* **[Tutorial de imágenes](https://www.w3.org/WAI/tutorials/images/)**
-* **[Tutorial de tablas](https://www.w3.org/WAI/tutorials/tables/)**
-* **[Tutorial de formularios](https://www.w3.org/WAI/tutorials/forms/)**
-* **[Tutorial de carruseles](https://www.w3.org/WAI/tutorials/carousels/)**
+* **[[Tutorial de estructura de la página]](/tutorials/page-structure/)**
+* **[[Tutorial de menús]](/tutorials/menus/)**
+* **[[Tutorial de imágenes]](/tutorials/images/)**
+* **[[Tutorial de tablas]](/tutorials/tables/)**
+* **[[Tutorial de formularios]](/tutorials/forms/)**
+* **[[Tutorial de carruseles]](/tutorials/carousels/)**
 
 ## Otros recursos de diseño y desarrollo
 

--- a/content/index.fr.md
+++ b/content/index.fr.md
@@ -44,19 +44,19 @@ Conseils pour la rédaction, la conception et le développement en faveur de l'a
 
 Les conseils suivants introduisent les éléments essentiels à prendre en considération pour rendre votre site Web plus accessible aux personnes en situation de handicap. Ils fournissent des liens vers des ressources supplémentaires.
 
-[Écrire pour l’accessibilité Web](/tips/writing/)
+[[Écrire pour l’accessibilité Web]](/tips/writing/)
 : Conseils pour écrire et présenter du contenu.
 
-[Concevoir pour l’accessibilité Web](/tips/designing/)
+[[Concevoir pour l’accessibilité Web]](/tips/designing/)
 : Conseils pour l’interface utilisateur et la conception visuelle.
 
-[Développer pour l’accessibilité Web](/tips/developing/)
+[[Développer pour l’accessibilité Web]](/tips/developing/)
 : Conseils pour le balisage et le code.
 {:.paragraph-like}
 
 ## Ressource multimédia pour l’audio et la vidéo
 
-[Rendre le contenu multimédia audio et vidéo accessible](https://www.w3.org/WAI/media/av/)
+[[Rendre le contenu multimédia audio et vidéo accessible]](/media/av/)
 : Vous aide à comprendre et à créer les légendes et les sous-titres, les audiodescriptions des informations visuelles, les transcriptions descriptives et le langage des signes pour le contenu multimédia. Inclut des conseils pour créer de nouvelles vidéos et en savoir plus sur l’accessibilité des lecteurs multimédia. Présente des cas utilisateurs et des bénéfices pour les organisations.
 {:.paragraph-like}
 
@@ -64,12 +64,12 @@ Les conseils suivants introduisent les éléments essentiels à prendre en consi
 
 Les tutoriels donnent des conseils pour créer des composants répondant aux exigences des Règles pour l’accessibilité des contenus Web (WCAG), plus accessibles aux personnes en situation de handicap et offrant une meilleure expérience utilisateur pour tous.
 
-* **[Tutoriel : structure d’une page](https://www.w3.org/WAI/tutorials/page-structure/)**
-* **[Tutoriel : menus](https://www.w3.org/WAI/tutorials/menus/)**
-* **[Tutoriel : images](https://www.w3.org/WAI/tutorials/images/)**
-* **[Tutoriel : tableaux](https://www.w3.org/WAI/tutorials/tables/)**
-* **[Tutoriel : formulaires](https://www.w3.org/WAI/tutorials/forms/)**
-* **[Tutoriel : carrousels](https://www.w3.org/WAI/tutorials/carousels/)**
+* **[[Tutoriel : structure d’une page]](/tutorials/page-structure/)**
+* **[[Tutoriel : menus]](/tutorials/menus/)**
+* **[[Tutoriel : images]](/tutorials/images/)**
+* **[[Tutoriel : tableaux]](/tutorials/tables/)**
+* **[[Tutoriel : formulaires]](/tutorials/forms/)**
+* **[[Tutoriel : carrousels]](/tutorials/carousels/)**
 
 ## Autres ressources pour la conception et le développement
 

--- a/content/index.fr.md
+++ b/content/index.fr.md
@@ -79,6 +79,6 @@ Les tutoriels donnent des conseils pour créer des composants répondant aux exi
 [Pratiques de création de WAI-ARIA](https://www.w3.org/TR/wai-aria-practices/)
 : Fournit des approches, des conseils, et des exemples pour aider les développeurs d’applications Web à créer des widgets, une navigation, et des comportements accessibles en utilisant les rôles, les états, et les propriétés WAI-ARIA (<i>Accessible Rich Internet Applications</i>).
 
-[Développer des sites Web pour les personnes âgées : comment s’appliquent les WCAG](https://www.w3.org/WAI/older-users/developing/)
+[Développer des sites Web pour les personnes âgées : comment s’appliquent les WCAG](/older-users/developing/)
 : Liste les critères de réussite et les techniques spécifiques des WCAG qui visent à améliorer l’accessibilité et l’ergonomie pour les personnes âgées.
 {:.paragraph-like}

--- a/content/index.md
+++ b/content/index.md
@@ -40,19 +40,19 @@ Guidance for writing, designing, and developing for accessibility.
 
 These tips introduce some basic considerations for making your website more accessible to people with disabilities. They provide links to additional guidance.
 
-[Writing for Web Accessibility](/tips/writing/) 
+[[Writing for Web Accessibility]](/tips/writing/) 
 : Tips for writing and presenting content.
 
-[Designing for Web Accessibility](/tips/designing/) 
+[[Designing for Web Accessibility]](/tips/designing/) 
 : Tips for user interface and visual design.
 
-[Developing for Web Accessibility](/tips/developing/) 
+[[Developing for Web Accessibility]](/tips/developing/) 
 : Tips for markup and coding.
 {:.paragraph-like}
 
 ## Media Resource for Audio and Video
 
-[Making Audio and Video Media Accessible](https://www.w3.org/WAI/media/av/)
+[[Making Audio and Video Media Accessible]](/media/av/)
 : Helps you understand and create captions/subtitles, audio description of visual information, descriptive transcripts, and sign language for media. Includes guidance for creating new videos, and on media player accessibility. Introduces user experiences and benefits to organizations.
 {:.paragraph-like}
 
@@ -60,12 +60,12 @@ These tips introduce some basic considerations for making your website more acce
 
 The tutorials provide guidance on how to create components that meet Web Content Accessibility Guidelines (WCAG), that are more accessible to people with disabilities, and that provide a better user experience for everyone.
 
-* **[Page Structure Tutorial](https://www.w3.org/WAI/tutorials/page-structure/)**
-* **[Menus Tutorial](https://www.w3.org/WAI/tutorials/menus/)**
-* **[Images Tutorial](https://www.w3.org/WAI/tutorials/images/)**
-* **[Tables Tutorial](https://www.w3.org/WAI/tutorials/tables/)**
-* **[Forms Tutorial](https://www.w3.org/WAI/tutorials/forms/)**
-* **[Carousels Tutorial](https://www.w3.org/WAI/tutorials/carousels/)**
+* **[[Page Structure Tutorial](/tutorials/page-structure/)**
+* **[[Menus Tutorial]](/tutorials/menus/)**
+* **[[Images Tutorial]](/tutorials/images/)**
+* **[[Tables Tutorial]](/tutorials/tables/)**
+* **[[Forms Tutorial]](/WAI/tutorials/forms/)**
+* **[[Carousels Tutorial]](/WAI/tutorials/carousels/)**
 
 ## Other Design and Development Resources
 
@@ -78,6 +78,6 @@ The tutorials provide guidance on how to create components that meet Web Content
 [Cognitive Accessibility Guidance](/WCAG2/supplemental/#cognitiveaccessibilityguidance)
 : Provides objectives and design patterns to improve accessibility for people with cognitive and learning disabilities. Introduced in [About Supplemental Guidance](/WCAG2/supplemental/about/).
 
-[Developing Websites for Older People: How WCAG Applies](https://www.w3.org/WAI/older-users/developing/)
+[Developing Websites for Older People: How WCAG Applies](/WAI/older-users/developing/)
 : Lists specific WCAG success criteria and techniques that particularly improve accessibility and usability for older people.
 {:.paragraph-like}

--- a/content/index.md
+++ b/content/index.md
@@ -78,6 +78,6 @@ The tutorials provide guidance on how to create components that meet Web Content
 [Cognitive Accessibility Guidance](/WCAG2/supplemental/#cognitiveaccessibilityguidance)
 : Provides objectives and design patterns to improve accessibility for people with cognitive and learning disabilities. Introduced in [About Supplemental Guidance](/WCAG2/supplemental/about/).
 
-[Developing Websites for Older People: How WCAG Applies](/WAI/older-users/developing/)
+[Developing Websites for Older People: How WCAG Applies](/older-users/developing/)
 : Lists specific WCAG success criteria and techniques that particularly improve accessibility and usability for older people.
 {:.paragraph-like}

--- a/content/index.md
+++ b/content/index.md
@@ -60,12 +60,12 @@ These tips introduce some basic considerations for making your website more acce
 
 The tutorials provide guidance on how to create components that meet Web Content Accessibility Guidelines (WCAG), that are more accessible to people with disabilities, and that provide a better user experience for everyone.
 
-* **[[Page Structure Tutorial](/tutorials/page-structure/)**
+* **[[Page Structure Tutorial]](/tutorials/page-structure/)**
 * **[[Menus Tutorial]](/tutorials/menus/)**
 * **[[Images Tutorial]](/tutorials/images/)**
 * **[[Tables Tutorial]](/tutorials/tables/)**
-* **[[Forms Tutorial]](/WAI/tutorials/forms/)**
-* **[[Carousels Tutorial]](/WAI/tutorials/carousels/)**
+* **[[Forms Tutorial]](/tutorials/forms/)**
+* **[[Carousels Tutorial]](/tutorials/carousels/)**
 
 ## Other Design and Development Resources
 


### PR DESCRIPTION
- Use of permalink when link goes to WAI website
- Use of double brackets when link text = title of the linked-to page

Following guidance [here](https://github.com/w3c/wai-resource-template/blob/master/content/index.md#heading-level-2) to support translations:  when the linked page is translated, the title of the translated page is inserted. When the linked page is not translated, then “(in English)” is added after the link

Resolves #14